### PR TITLE
Add README | Update DockerFiles | Add new verilator image | Added ini…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+This is a curated set of DockerFiles used to install riscv-tools and verilator versions.

--- a/b266e97-4_008/Dockerfile
+++ b/b266e97-4_008/Dockerfile
@@ -97,7 +97,7 @@ ENV PATH="$RISCV/bin:$PATH"
 RUN git clone http://git.veripool.org/git/verilator /tmp/verilator \
     && cd /tmp/verilator \
     && git pull \
-    && git checkout verilator_3_922 \
+    && git checkout verilator_4_008 \
     && unset VERILATOR_ROOT \
     && autoconf \
     && ./configure \

--- a/push_to_dockerhub.sh
+++ b/push_to_dockerhub.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# push the specified dockerfile to the ucb-bar docker repo with specified tag
+# ./push_to_dockerhub.sh folderToBuildAndPush
+#
+# requires you to have docker and have permissions to push to docker repo
+
+cd $1
+sudo docker build -t ucbbar/riscv-docker-images:$1 .
+sudo docker push ucbbar/riscv-docker-images:$1
+


### PR DESCRIPTION
Addresses concerns in #1. There is now a new DockerFile for verilator 4.008, sbt install is from the documentation at https://www.scala-sbt.org/release/docs/Installing-sbt-on-Linux.html. Additionally, the non-interactive debian frontend has been disabled.